### PR TITLE
Fix artifact action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm ci
       - run: make public
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 
@@ -37,4 +37,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- bump actions/upload-pages-artifact to v3
- bump actions/deploy-pages to v4

## Testing
- `npm install`
- `make public` *(fails: Forbidden - files.openscad.org)*
- `npm run build` *(fails: openscad.js missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888a90e7954832daff8dac7c2b8a204